### PR TITLE
[mm] Calloc Support

### DIFF
--- a/include/nanvix/ulib.h
+++ b/include/nanvix/ulib.h
@@ -96,6 +96,58 @@
 /**@}*/
 
 /*============================================================================*
+ * Memory Allocation                                                          *
+ *============================================================================*/
+
+/**
+ * @addtogroup ulib-memory
+ * @ingroup ulib
+ */
+/**@{*/
+
+	/**
+	 * @brief Allocates @p size bytes on memory.
+	 *
+	 * @param size Size (in bytes) to be allocated.
+	 *
+	 * @returns Upon successful completion, a pointer to the allocated
+	 * region is returned. A NULL pointer is returned instead.
+	 */
+	extern void * umalloc(size_t size);
+
+	/**
+	 * @brief Allocates an amount of bytes to store @p num elements
+	 * on memory.
+	 *
+	 * @param num  Number of elements to be stored.
+	 * @param size Size of each element.
+	 *
+	 * @returns Upon successful completion, a pointer to the allocated
+	 * region is returned. A NULL pointer is returned instead.
+	 */
+	extern void * ucalloc(unsigned int num, size_t size);
+
+	/**
+	 * @brief Reallocates a memory region freeing the original one.
+	 *
+	 * @param ptr  Pointer to the original memory region.
+	 * @param size Size of the new region to be allocated.
+	 *
+	 * @returns Upon successful completion, a pointer to the new
+	 * allocated region is returned. A NULL pointer is returned instead.
+	 */
+	extern void *urealloc(void *ptr, size_t size);
+
+	/**
+	 * @brief Frees a memory region to be used again.
+	 *
+	 * @param ptr Pointer to the memory region to be released.
+	 */
+	extern void ufree(void *ptr);
+
+/**@}*/
+
+/*============================================================================*
  * String Manipulation                                                        *
  *============================================================================*/
 

--- a/src/umalloc.c
+++ b/src/umalloc.c
@@ -185,20 +185,32 @@ void *umalloc(size_t size)
 }
 
 /**
- * @brief Allocates memory.
+ * @brief Allocates memory to hold @p num elements of size @p size,
+ * and initializes it to zero.
  *
  * @param num  Number of elements of @p size to be allocated.
  * @param size Number of bytes of one element.
  *
- * @see umalloc().
+ * @returns Pointer to the new allocated region.
  */
 void * ucalloc(unsigned int num, size_t size)
 {
+	void *p;
+	size_t num_bytes;
+
+	num_bytes = num * size;
+
 	/* Nothing to be done. */
-	if ((num == 0) || (size == 0))
+	if (num_bytes == 0)
 		return (NULL);
 
-	return (umalloc(num * size));
+	p = umalloc(num_bytes);
+
+	/* Initializes the region to ZERO. */
+	if (p != NULL)
+		umemset(p, 0, num_bytes);
+
+	return (p);
 }
 
 /**

--- a/src/umalloc.c
+++ b/src/umalloc.c
@@ -185,6 +185,23 @@ void *umalloc(size_t size)
 }
 
 /**
+ * @brief Allocates memory.
+ *
+ * @param num  Number of elements of @p size to be allocated.
+ * @param size Number of bytes of one element.
+ *
+ * @see umalloc().
+ */
+void * ucalloc(unsigned int num, size_t size)
+{
+	/* Nothing to be done. */
+	if ((num == 0) || (size == 0))
+		return (NULL);
+
+	return (umalloc(num * size));
+}
+
+/**
  * @brief Reallocates a memory chunk.
  *
  * @param ptr  Pointer to old object.


### PR DESCRIPTION
# Description #
In this PR was introduced the support to the `calloc()` function on the memory allocator. Also, the interface of the memory allocator was added to `ulib.h`, permitting the user to use its functions, what were forgot on the last PR.

# Related PRs # 
- Complements the PR #14 [- [mm] Static Array Based Memory Allocator](https://github.com/nanvix/ulibc/pull/14) 