### PR TITLE
Enhancement: Initialization of the kernel NoC interface

### DIFF
--- a/src/crt0.c
+++ b/src/crt0.c
@@ -25,6 +25,7 @@
 #include <nanvix/ulib.h>
 #include <posix/stddef.h>
 #include <nanvix/sys/thread.h>
+#include <nanvix/sys/noc.h>
 
 /*
  * System-level main routine.
@@ -44,6 +45,8 @@ void ___start(int argc, const char *argv[], char **envp)
 	int ret;
 
 	environ = envp;
+
+	knoc_init();
 
 	ret = __main2(argc, argv);
 


### PR DESCRIPTION
In this PR, I add the call of `knoc_init` on `___start` function and update the Libnanvix submodule.

## Related submodule PR

[[ikc] Feature: Implementation of the Sync and Portal using mailboxes](https://github.com/nanvix/libnanvix/pull/38)