### PR TITLE
[mm] Umalloc Bugfixes

### DIFF
--- a/src/umalloc.c
+++ b/src/umalloc.c
@@ -150,7 +150,7 @@ void *umalloc(size_t size)
 	}
 
 	/* Look for a free block that is big enough. */
-	for (p = &head; /* void */ ; prevp = p, p = p->nextp)
+	for (p = prevp->nextp; /* void */ ; prevp = p, p = p->nextp)
 	{
 		/* Found. */
 		if (p->size >= size)

--- a/src/umalloc.c
+++ b/src/umalloc.c
@@ -65,7 +65,7 @@ void ufree(void *ptr)
 	bp = (struct block *)ptr - 1;
 
 	/* Look for insertion point. */
-	for (p = freep; !(p < bp && p->nextp > bp); p = p->nextp)
+	for (p = freep; !(p <= bp && p->nextp >= bp); p = p->nextp)
 	{
 		/* Freed block at start or end. */
 		if (p >= p->nextp && (bp > p || bp < p->nextp))
@@ -100,8 +100,8 @@ void ufree(void *ptr)
  *
  * @param size Number of bytes to expand.
  *
- * @returns Upon successful completion a pointed to the expansion is returned.
- *          Upon failure, a null pointed is returned instead and errno is set
+ * @returns Upon successful completion a pointer to the expansion is returned.
+ *          Upon failure, a NULL pointer is returned instead and errno is set
  *          to indicate the error.
  */
 static void *expand(size_t size)
@@ -150,7 +150,7 @@ void *umalloc(size_t size)
 	}
 
 	/* Look for a free block that is big enough. */
-	for (p = freep; /* void */ ; prevp = p, p = p->nextp)
+	for (p = &head; /* void */ ; prevp = p, p = p->nextp)
 	{
 		/* Found. */
 		if (p->size >= size)


### PR DESCRIPTION
# Description #
In this PR, two small bugfixes were made on the array based memory allocator. Below we explain the bugfixes in detail.

- ### Ufree Insertion Point Lookup (Line #68) ###
This bugfix resolves the `ufree()` insertion point problem. We know that the block address is `ptr-1`, which is defined in the line 65. This means that this address can also be equal to the base values on the break condition, rather than only greater or lesser.

- ### Umalloc Free Block Lookup Initialization (Line #153) ###
This bugfix can be a simple workaround for an untracked problem related with the `freep` variable updating. Initializing the loop to the head of the free list seems to work better than counting that `freep` is always the address of the first free block.