### PR TITLE
Wrong Block Arithmetic in The umalloc()

### DIFF
--- a/src/ulibc/glue.c
+++ b/src/ulibc/glue.c
@@ -62,7 +62,7 @@ void *__nanvix_sbrk(size_t size)
 
 	/* Cannot increase break value. */
 	if ((brk < heap.data) || (brk >= (heap.data + HEAP_SIZE)))
-		return ((void *) -1);
+		return (NULL);
 
 	heap.brk = brk;
 


### PR DESCRIPTION
In this PR, I define a minimum block size to be able to store meta-information and user data without overwrite of blocks in `umalloc` function.

I also fix pointer arithmetic in separating a large block into two smaller ones. Before, it sums an offset in bytes to a `struct block` pointer, larger than a byte. This caused the new pointer to stop over other blocks or even leave the heap.