### PR TITLE
Use KTHREAD_LEADER_TID on exit / Drop __vsprintf function

### DIFF
--- a/include/nanvix/ulib.h
+++ b/include/nanvix/ulib.h
@@ -240,9 +240,9 @@
 /**@{*/
 
 	/**
-	 * @see __vsprintf().
+	 * @see __vsnprintf().
 	 */
-	#define uvsprintf(str,fmt,args) __vsprintf(str,fmt,args)
+	#define uvsprintf(str,size,fmt,args) __vsnprintf(str,size,fmt,args)
 
 	/**
 	 * @see __sprintf().

--- a/src/ulibc/glue.c
+++ b/src/ulibc/glue.c
@@ -74,7 +74,7 @@ void *__nanvix_sbrk(size_t size)
  */
 NORETURN void ___nanvix_exit(int status)
 {
-	if (kthread_self() == 1)
+	if (kthread_self() == KTHREAD_LEADER_TID)
 		_kexit(status);
 	else
 		kthread_exit(&status);

--- a/src/ulibc/uprintf.c
+++ b/src/ulibc/uprintf.c
@@ -31,14 +31,14 @@
  */
 int uprintf(const char *fmt, ...)
 {
-	size_t len;       /* String length.           */
-	va_list args;     /* Variable arguments list. */
-	char buffer[256]; /* Temporary buffer.        */
+	size_t len;                    /* String length.           */
+	va_list args;                  /* Variable arguments list. */
+	char buffer[KBUFFER_SIZE + 1]; /* Temporary buffer.        */
 
 	/* Convert to raw string. */
 	va_start(args, fmt);
-	len = uvsprintf(buffer, fmt, args);
-	buffer[len++] = '\0';
+	len = uvsprintf(buffer, KBUFFER_SIZE + 1, fmt, args);
+	buffer[++len] = '\0';
 	va_end(args);
 
 	nanvix_write(0, buffer, ustrlen(buffer));


### PR DESCRIPTION
In this PR, I introduce an enhancement and a bugfix.

- Feature: Because of the introduction of the thread scheduler, I modify the user leader TID to use the constant on `__nanvix_exit` function.

- Bugfix: `__vsprintf` is not supported anymore, so I drop it and use `_vsnprintf` in its place.

## Related Submodule PRs

[[tm] Feature: User-side support for thread scheduler #56](https://github.com/nanvix/libnanvix/pull/56)